### PR TITLE
Adding @content and @live tags to Scenarios that look for content and…

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,19 +6,24 @@ Behat tests mean death to linky-clicky
 Notes on Directory Structure
 ----------------------------
 
-When creating a set of testing features for a new site, create a new directory for that site. Copy behat.yml.default into the root of that directory and rename it to "behat.yml". Edit the "base_url" and the drush "alias" values to match the site you are testing.
+When creating a set of testing features for a new site, create a new directory for that site. Copy `behat.yml.default` and `behat.local.yml.default` into the root of that directory and rename them to `behat.yml` and `behat.local.yml`, respectively. Edit the "base_url" and the drush "alias" values to match the site you are testing.
 
-Create a "features" directory and place your *.feature files in that directory.
+`behat.yml` imports the files at `includes/extensions/drupal.extension.yml` and `includes/extensions/mink.extension.yml`.
 
-Create a "features/bootstrap" directory, copy FeatureContext.php.default into there, and rename it FeatureContext.php
+`behat.local.yml` is ignored by git.
 
-The default FeatureContext.php file contains some additional step definitions, and an override of the Drupal login step, which is necessary because WMD hides the user login form in a collapsible fieldset
+Create a `features` directory and place your `*.feature` files in that directory.
+
+Create a `features/bootstrap` directory, copy `FeatureContext.php.default` into there, and rename it `FeatureContext.php`
+
+The default `FeatureContext.php` file includes the file at `includes/bootstrap/SWSFeatureContext.php`, which contains some additional step definitions, and an override of the Drupal login step, which is necessary because WMD hides the user login form in a collapsible fieldset.
 
 Directory structure
 -------------------
 
     sitename
     |--behat.yml
+    |--behat.local.yml
     |--features
        |--featurename.feature
        |--bootstrap

--- a/jsa/features/about.feature
+++ b/jsa/features/about.feature
@@ -3,14 +3,17 @@ Feature: About
   As an end user
   I want to check for the existence of page and block content
 
+  @content @live
   Scenario: Viewing a featured image on the About page
     Given I am on "about/about-us"
     Then I should see "Arcade on the Quad" in the "Content Body" region
 
+  @content @live
   Scenario: Viewing a postcard block with Google Maps embed on the Location page
     Given I am on "about/location"
     Then I should see the link "View Larger Map"
 
+  @content @live
   Scenario: Clicking the sidebar menu
     Given I am on "about/contact"
     And I click "Overview" in the "First sidebar" region

--- a/jsa/features/academics.feature
+++ b/jsa/features/academics.feature
@@ -3,25 +3,30 @@ Feature: Academics
   As an end user
   I want to check for the existence of page and block content
 
+  @content @live
   Scenario: Viewing a featured image on the Undergraduate Programs page
     Given I am on "academics/undergraduate-program"
     Then I should see "Undergraduates studying outside Meyer" in the "Content Body" region
 
+  @content @live
   Scenario: Viewing a postcard block on the Graduate Programs page
     Given I am on "academics/graduate-programs"
     Then I should see "Our Graduate Students" in the "First sidebar" region
 
+  @content @live
   Scenario: Clicking the sidebar menu
     Given I am on "academics/graduate-programs"
     And I click "Overview" in the "First sidebar" region
     Then I should see "This is your Academics Overview page" in the "Content Body" region
 
+  @content @live
   Scenario: Verifying correct link on Academics Overview page
     Given I am on "academics"
     And I click "Learn more about the undergraduate program" in the "Content Body" region
     Then I should be on "academics/undergraduate-program"
 
-Scenario: Verifying correct link on Academics Overview page
+  @content @live
+  Scenario: Verifying correct link on Academics Overview page
     Given I am on "academics"
     And I click "Learn more about the graduate programs" in the "Content Body" region
     Then I should be on "academics/graduate-programs"

--- a/jsa/features/courses.feature
+++ b/jsa/features/courses.feature
@@ -3,17 +3,20 @@ Feature: Courses
   As an end user
   I want to check for the existence of courses content
 
+  @content @live
   Scenario: View current courses and Featured Course sidebar block
     Given I am on "courses"
     Then I should see "Current Courses"
     And I should see the "Featured Course" heading in the "First sidebar" region
 
+  @content @live
   Scenario: Searching courses by academic year
     Given I am on "courses"
     When I select "2014-2015" from "Academic year"
     And I press "Go"
     Then I should get a "200" HTTP response
 
+  @content @live
   Scenario: Finding a specific course and seeing it has multiple sections
     Given I am on "courses"
     When I enter "e" for "Search all courses by keyword"
@@ -23,21 +26,25 @@ Feature: Courses
     And I press "Go"
     Then I should see "No courses are available based on your search." in the "Content Body" region
 
+  @content @live
   Scenario: Reset button links to search page
     Given I am on "courses"
     And I press "Reset"
     Then I should be on "courses/search"
 
+  @content @live
   Scenario: No results text when there are courses, but none for given search
     Given I am on "courses"
     When I enter "Underwater basketweaving" for "Search all courses by keyword"
     And I press "Go"
     Then I should see "No courses are available based on your search." in the "Content Body" region
 
+  @content @live
   Scenario: No current courses block for person not teaching any courses
     Given I am on "people/emily-jordan"
     Then I should not see "Current Courses" in the "Second sidebar" region
 
+  @content @live
   Scenario: Enhanced courses search functionality
     Given I am on "courses"
     When I enter "English 9ce" for "Search all courses by keyword"

--- a/jsa/features/events.feature
+++ b/jsa/features/events.feature
@@ -3,22 +3,27 @@ Feature: Events
   As an end user
   I want to check for the existence of events content
 
+  @content @live
   Scenario: See upcoming events on homepage
     Given I am on the homepage
     Then I should see the "Upcoming Events" heading in the "Content 3 column flow" region
 
+  @content @live
   Scenario: See upcoming events content
     Given I am on "events/upcoming-events"
     Then I should see a ".event-title" element
 
+  @content @live
   Scenario: See calendar nav block
     Given I am on "events/upcoming-events"
     Then I should see a ".date-nav-wrapper" element
 
+  @content @live
   Scenario: See past events - check for pager
     Given I am on "events/past-events"
     Then I should see 5 or fewer ".event-title" elements
 
+  @content @live
   Scenario: Searching events
     Given I am on "events/upcoming-events"
     When I select "Lecture" from "Filter by type"

--- a/jsa/features/news.feature
+++ b/jsa/features/news.feature
@@ -3,17 +3,20 @@ Feature: News
   As an end user
   I want to check for the existence of news content
 
+  @content @live
   Scenario: See more news
     Given I am on the homepage
     And I click "See more news" in the "Content 3 column flow" region
     Then I should see the heading "Recent News" in the "Content" region
 
+  @content @live
   Scenario: Searching news
     Given I am on "news/recent-news"
     When I fill in "Search by title" with "Sample News: Smith Conference"
     And I press "Go"
     Then I should see "This is a news item" in the "Content Body" region
 
+  @content @live
   Scenario: See a news node
     Given I am on "news/2013-sample-news-smith-conference"
     Then I should see "Smith Conference is proin lacus lacus, eleifend tristique volutpat vitae, mattis nec nisl" in the "Content Body" region

--- a/jsa/features/page_not_found.feature
+++ b/jsa/features/page_not_found.feature
@@ -3,7 +3,7 @@ Feature: Page not Found - 404
   As an end user
   I want to check for the existence of the page
 
-  @javascript
+  @javascript @content @live
   Scenario: Check content of the custom 404 page
     Given I am on "purple-monkey-dishwasher"
     Then I should see "Oops" in the "Content Body" region

--- a/jsa/features/people.feature
+++ b/jsa/features/people.feature
@@ -3,6 +3,7 @@ Feature: People
   As an end user
   I want to check for the existence of people content
 
+  @content @live
   Scenario: List of faculty
     Given I am on "people/faculty"
     Then I should see a ".views-row-first" element
@@ -11,11 +12,13 @@ Feature: People
     And I should see the "People" heading in the "First sidebar" region
     And I should see "This is your Why I Teach block" in the "First sidebar" region
 
+  @content @live
   Scenario: Faculty node
     Given I am on "people/faculty"
     And I click "Jacob Smith" in the "Content Body" region
     Then I should see "Professor of English" in the "Content Body" region
 
+  @content @live
   Scenario: Faculty taxonomy filter
     Given I am on "people/faculty"
     When I select "Professor" from "Filter by faculty status"
@@ -23,44 +26,52 @@ Feature: People
     Then I should see "Jacob Smith" in the "Content Body" region
     And I should not see "Jane Doe" in the "Content Body" region
 
+  @content @live
   Scenario: List of staff
     Given I am on "people/staff"
     Then I should see a ".views-row-first" element
     And I should see a ".views-row-lines" element
 
+  @content @live
   Scenario: List of students
     Given I am on "people/students"
     Then I should see a ".views-row-first" element
     And I should see a ".views-row-lines" element
 
-  Scenario: Students layout with faculty 
+  @content @live
+  Scenario: Students layout with faculty
     Given I am on "people/students/faculty"
     Then I should see "Faculty" in the "Content Head" region 
     And I should see "Jacob Smith" in the "Content Body" region
 
-  Scenario: Faculty layout 
+  @content @live
+  Scenario: Faculty layout
     Given I am on "people/faculty"
     Then I should see a ".views-exposed-form" element
     And I should see "People" in the "First sidebar" region 
     And I should see "Why I Teach" in the "First sidebar" region
 
-  Scenario: Students layout 
+  @content @live
+  Scenario: Students layout
     Given I am on "people/students"
     Then I should see a ".views-exposed-form" element
-    And I should see "People" in the "First sidebar" region 
+    And I should see "People" in the "First sidebar" region
 
-  Scenario: Staff layout 
+  @content @live
+  Scenario: Staff layout
     Given I am on "people/staff"
     Then I should see a ".views-exposed-form" element
     And I should see "People" in the "First sidebar" region 
     And I should see "Contact and Location" in the "First sidebar" region
 
-  Scenario: Staff layout with faculty 
+  @content @live
+  Scenario: Staff layout with faculty
     Given I am on "people/staff/faculty"
     Then I should see "Faculty" in the "Content Head" region 
     And I should see "Jacob Smith" in the "Content Body" region
 
-  Scenario: Faculty layout with staff 
+  @content @live
+  Scenario: Faculty layout with staff
     Given I am on "people/faculty/staff"
     Then I should see "Emily Jordan" in the "Content Body" region
     And I should see "Staff" in the "Content Head" region 

--- a/jsa/features/publications.feature
+++ b/jsa/features/publications.feature
@@ -3,29 +3,34 @@ Feature: Publications
   As an end user
   I want to check for the existence of publication content
 
+  @content @live
   Scenario: Filter publications by title
     Given I am on "publications"
     When I fill in "Filter by title" with "book title two"
     And I press "Go"
     Then I should see "Sample Publication: Book Title Two" in the "Content Body" region
 
+  @content @live
   Scenario: Filter publications by author
     Given I am on "publications"
     When I fill in "Filter by author" with "Marvin C. Ferrell"
     And I press "Go"
     Then I should see "Marvin C. Ferrell" in the "Content Body" region
 
+  @content @live
   Scenario: Filter publications by type
     Given I am on "publications"
     When I select "Book" from "Filter by type"
     And I press "Go"
     Then I should see "Sample Publication: Book Title Two" in the "Content Body" region
 
+  @content @live
   Scenario: Click through to publication
     Given I am on "Publications"
     When I click "Sample Publication: Book Title Two" in the "Content Body" region
     Then I should see "This is a publication." in the "Content Body" region
 
+  @content @live
   Scenario: Publication showing correct image size
     Given I am on "publications/sample-publication-book-title-two"
     Then I should see a ".view-mode-stanford-large-scaled" element

--- a/jsplus/features/about.feature
+++ b/jsplus/features/about.feature
@@ -3,10 +3,12 @@ Feature: About
   As an end user
   I want to check for the existence of page and block content
 
+  @content @live
   Scenario: Viewing a featured image on the About page
     Given I am on "about"
     Then I should see "Arcade on the Quad" in the "Content Body" region
 
+  @content @live
   Scenario: Clicking the sidebar menu
     Given I am on "about/contact"
     Then I should see "This is your Contact page" in the "Content Body" region

--- a/jsplus/features/page_not_found.feature
+++ b/jsplus/features/page_not_found.feature
@@ -3,7 +3,7 @@ Feature: Page not Found - 404
   As an end user
   I want to check for the existence of the page
 
-  @javascript
+  @javascript @content @live
   Scenario: Check content of the custom 404 page
     Given I am on "purple-monkey-dishwasher"
     Then I should see "Oops" in the "Content Body" region

--- a/jsv/features/about.feature
+++ b/jsv/features/about.feature
@@ -3,10 +3,12 @@ Feature: About
   As an end user
   I want to check for the existence of page and block content
 
+  @content @live
   Scenario: Viewing a featured image on the About page
     Given I am on "about"
     Then I should see "Arcade on the Quad" in the "Content Body" region
 
+  @content @live
   Scenario: Clicking the sidebar menu
     Given I am on "about/contact"
     Then I should see "This is your Contact page" in the "Content Body" region

--- a/jsv/features/contact.feature
+++ b/jsv/features/contact.feature
@@ -3,6 +3,7 @@ Feature: Contact
   As an end user
   I want to check for the existence of page and block content
 
+  @content @live
   Scenario: Viewing information on the Contact page
     Given I am on "about/contact"
     # See the Accessibility contnent

--- a/jsv/features/events.feature
+++ b/jsv/features/events.feature
@@ -3,6 +3,7 @@ Feature: Events
   As an end user
   I want to check for the existence of the page
 
+  @content @live
   Scenario: Check the contents of the "Events" page
     Given I am on "events"
     Then I should see the heading "Sample Event" in the "Content Body" region

--- a/jsv/features/news.feature
+++ b/jsv/features/news.feature
@@ -3,6 +3,7 @@ Feature: News
   As an end user
   I want to check for the existence of the page
 
+  @content @live
   Scenario: Check the content of the News page
     Given I am on "news"
     Then I should see the heading "Sample News" in the "Content Body" region

--- a/jsv/features/page_not_found.feature
+++ b/jsv/features/page_not_found.feature
@@ -3,7 +3,7 @@ Feature: Page not Found - 404
   As an end user
   I want to check for the existence of the page
 
-  @javascript
+  @javascript @content @live
   Scenario: Check content of the custom 404 page
     Given I am on "purple-monkey-dishwasher"
     Then I should see "Oops" in the "Content Body" region

--- a/jsv/features/research.feature
+++ b/jsv/features/research.feature
@@ -3,6 +3,7 @@ Feature: Research
   As an end user
   I want to check for the existence of the page
 
+  @content @live
   Scenario: Check the contents of the "Research" page
     Given I am on "research"
     Then I should see 1 or more ".group_s_postcard_image" elements


### PR DESCRIPTION
… can be run on a live site.

@sherakama take a look. I wonder if we should fine-tune this further and use `@content` for Scenarios that look for default content, and `@live` for Scenarios that look for classes and headings (things that should exist on a production JSA site).

@boznik just FYI.