### PR TITLE
Track variables so that the world doesn't end

### DIFF
--- a/includes/bootstrap/SWSFeatureContext.php
+++ b/includes/bootstrap/SWSFeatureContext.php
@@ -462,34 +462,6 @@ JS;
   }
 
   /**
-   * Track the original state of a changed variable.
-   */
-  protected function trackChangedVariable($name, $value) {
-    if (!key_exists($name, $this->changedVariables)) {
-      $this->changedVariables[$name] = $value;
-    }
-  }
-
-  /**
-   * Set changed variables to their original state.
-   *
-   * @AfterScenario
-   */
-  public function resetVariables() {
-    foreach ($this->changedVariables as $var => $value) {
-      if (isset($value)) {
-        // If the original value was something other than NULL, set it back.
-        variable_set($var, $value);
-      }
-      else {
-        // Unset the variable if it didn't exist before.
-        variable_del($var);
-      }
-    }
-  }
-
-
-  /**
    * @Then the href in element :arg1 should contain :arg2
    */
   public function theHrefInElementShouldContain($element_id, $pattern) {

--- a/includes/config/default.yml
+++ b/includes/config/default.yml
@@ -6,7 +6,6 @@ default:
         - Drupal\DrupalExtension\Context\MessageContext
         - Drupal\DrupalExtension\Context\DrushContext
         - Drupal\DrupalExtension\Context\MarkupContext
-        - Drupal\DrupalExtension\Context\DrushContext
         - Drupal\DrupalExtension\Context\BatchContext
         - FeatureContext
         - SWSFeatureContext
@@ -22,7 +21,6 @@ default:
         - Drupal\DrupalExtension\Context\MessageContext
         - Drupal\DrupalExtension\Context\DrushContext
         - Drupal\DrupalExtension\Context\MarkupContext
-        - Drupal\DrupalExtension\Context\DrushContext
         - Drupal\DrupalExtension\Context\BatchContext
         - FeatureContext
         - SWSFeatureContext
@@ -39,7 +37,6 @@ default:
         - Drupal\DrupalExtension\Context\MessageContext
         - Drupal\DrupalExtension\Context\DrushContext
         - Drupal\DrupalExtension\Context\MarkupContext
-        - Drupal\DrupalExtension\Context\DrushContext
         - Drupal\DrupalExtension\Context\BatchContext
         - FeatureContext
         - SWSFeatureContext
@@ -56,7 +53,6 @@ default:
         - Drupal\DrupalExtension\Context\MessageContext
         - Drupal\DrupalExtension\Context\DrushContext
         - Drupal\DrupalExtension\Context\MarkupContext
-        - Drupal\DrupalExtension\Context\DrushContext
         - Drupal\DrupalExtension\Context\BatchContext
         - FeatureContext
         - SWSFeatureContext
@@ -73,7 +69,6 @@ default:
         - Drupal\DrupalExtension\Context\MessageContext
         - Drupal\DrupalExtension\Context\DrushContext
         - Drupal\DrupalExtension\Context\MarkupContext
-        - Drupal\DrupalExtension\Context\DrushContext
         - Drupal\DrupalExtension\Context\BatchContext
         - FeatureContext
         - SWSFeatureContext
@@ -90,7 +85,6 @@ default:
         - Drupal\DrupalExtension\Context\MessageContext
         - Drupal\DrupalExtension\Context\DrushContext
         - Drupal\DrupalExtension\Context\MarkupContext
-        - Drupal\DrupalExtension\Context\DrushContext
         - Drupal\DrupalExtension\Context\BatchContext
         - FeatureContext
         - SWSFeatureContext
@@ -107,7 +101,6 @@ default:
         - Drupal\DrupalExtension\Context\MessageContext
         - Drupal\DrupalExtension\Context\DrushContext
         - Drupal\DrupalExtension\Context\MarkupContext
-        - Drupal\DrupalExtension\Context\DrushContext
         - Drupal\DrupalExtension\Context\BatchContext
         - FeatureContext
         - SWSFeatureContext
@@ -124,7 +117,6 @@ default:
         - Drupal\DrupalExtension\Context\MessageContext
         - Drupal\DrupalExtension\Context\DrushContext
         - Drupal\DrupalExtension\Context\MarkupContext
-        - Drupal\DrupalExtension\Context\DrushContext
         - Drupal\DrupalExtension\Context\BatchContext
         - FeatureContext
         - SWSFeatureContext
@@ -141,7 +133,6 @@ default:
         - Drupal\DrupalExtension\Context\MessageContext
         - Drupal\DrupalExtension\Context\DrushContext
         - Drupal\DrupalExtension\Context\MarkupContext
-        - Drupal\DrupalExtension\Context\DrushContext
         - Drupal\DrupalExtension\Context\BatchContext
         - FeatureContext
         - SWSFeatureContext
@@ -158,7 +149,6 @@ default:
         - Drupal\DrupalExtension\Context\MessageContext
         - Drupal\DrupalExtension\Context\DrushContext
         - Drupal\DrupalExtension\Context\MarkupContext
-        - Drupal\DrupalExtension\Context\DrushContext
         - Drupal\DrupalExtension\Context\BatchContext
         - FeatureContext
         - SWSFeatureContext

--- a/jse/features/administration.feature
+++ b/jse/features/administration.feature
@@ -25,6 +25,7 @@ Feature: Administration
   Scenario: Help text and request assistance url changes
     Given I am logged in as a user with the "administrator" role
     When I go to "admin/stanford-jumpstart/settings"
+    And I track variable "stanford_jumpstart_help_settings"
     Then I fill in "Help text" with "My new and wonderful help text."
     Then I fill in "Request assistance url" with "https://test.stanford.edu"
     Then I press "Save"


### PR DESCRIPTION
- Added new track variables step definition that uses Drush
- Removed a duplicate context from the main settings.
- Added track changes to the destructive call in the JSE administration feature.

To test, merge with latest behat3
Run from JSE folder: `behat features/administration.feature:25 --profile local --suite all`
