### PR TITLE
Make stanford_metatag_nobots great again

### DIFF
--- a/includes/features/SU-SWS/stanford_metatag_nobots/stanford_metatag_nobots.feature
+++ b/includes/features/SU-SWS/stanford_metatag_nobots/stanford_metatag_nobots.feature
@@ -4,14 +4,16 @@ Feature: Stanford MetaTag NoBots
   As an administrative user
   I want to ensure that the Stanford MetaTag NoBots module is working properly
 
-  @api @dev @safe
+  @api @dev @destructive
   Scenario: Stanford MetaTag NoBots
+    Given the "stanford_metatag_nobots" module is enabled
     And the cache has been cleared
     And I am on the homepage
     Then the response header "X-Robots-Tag" should contain "noindex,nofollow,noarchive"
 
-  @api @live @safe
-  Scenario: Stanford MetaTag NoBots
+  @api @dev @destructive
+  Scenario: Stanford MetaTag NoBots Disabled
+    Given the "stanford_metatag_nobots" module is disabled
     And the cache has been cleared
     And I am on the homepage
     Then the response header should not have "X-Robots-Tag"


### PR DESCRIPTION
Not sure about the tags on the `Stanford Metatag NoBots Disabled` scenario. I understand that we want one for `@live` and `@safe`, but I'm not sure if we're considering disabling a module destructive. I think I would.
