### PR TITLE
Support old JSA 3x Site Actions menu

### DIFF
--- a/includes/bootstrap/SWSFeatureContext.php
+++ b/includes/bootstrap/SWSFeatureContext.php
@@ -229,7 +229,7 @@ class SWSFeatureContext extends RawDrupalContext implements Context, SnippetAcce
     $mink = $this->minkContext;
 
     $mink->getSession()->getDriver()->evaluateScript(
-    "jQuery('#block-menu-menu-admin-shortcuts ul.nav li.first.last, #block-menu-menu-admin-shortcuts ul.nav li.expanded:first').find('ul').show().css('z-index', '1000');"
+    "jQuery('#block-menu-menu-admin-shortcuts ul.nav li.first.last, #block-menu-menu-admin-shortcuts ul.nav li.expanded:first, #block-menu-menu-admin-shortcuts-site-action ul.nav li.expanded:first').find('ul').show().css('z-index', '1000');"
     );
 
     $mink->getSession()->wait(3000, "jQuery('#block-menu-menu-admin-shortcuts ul.nav > ul.nav').children().length > 0");


### PR DESCRIPTION
## To test:
1. Check out `5.x`
2. Run `sites/classics/features/site_owner.feature`
3. Sob quietly when it fails
4. Check out `site-actions-jsa-3x`
5. Run `sites/classics/features/site_owner.feature`
6. Rejoice
7. Run `products/jsa/features/site_owner.feature` to ensure that this hasn't introduced a regression
