### PR TITLE
Wait for AJAX to finish before testing Context Block Class

### DIFF
--- a/sites/uat/features/cbc.feature
+++ b/sites/uat/features/cbc.feature
@@ -24,6 +24,7 @@ Feature: Contextual Block Class
     And I press the "Save" button
     And I go to "admin/structure/block/manage/system/powered-by/configure"
     And I click "Contextual Block Class(es)"
+    # Collapsed fieldset
     And I wait for AJAX to finish
     And I enter "cbc-test-class" for "cbc-test-context"
     And I select "Footer" from "Stanford Light (default theme)"

--- a/sites/uat/features/cbc.feature
+++ b/sites/uat/features/cbc.feature
@@ -24,6 +24,7 @@ Feature: Contextual Block Class
     And I press the "Save" button
     And I go to "admin/structure/block/manage/system/powered-by/configure"
     And I click "Contextual Block Class(es)"
+    And I wait for AJAX to finish
     And I enter "cbc-test-class" for "cbc-test-context"
     And I select "Footer" from "Stanford Light (default theme)"
     And I press the "Save block" button


### PR DESCRIPTION
We testing this locally; previously the test was failing because the element was not visible.
