### PR TITLE
Fixes to stanford_gallery for JS actions on local environment

### DIFF
--- a/includes/features/SU-SWS/stanford_gallery/stanford_gallery.feature
+++ b/includes/features/SU-SWS/stanford_gallery/stanford_gallery.feature
@@ -80,18 +80,21 @@ Scenario: Create stanford gallery node
 
   Then I should see 1 "#colorbox" element
   When I hover over the element "#cboxContent"
+  And I wait for AJAX to finish
   # TODO: Make these work...
   # Then I should see 1 "#colorbox .caption" element
   # Then I should see 1 "#colorbox .credits" element
   Then I click on the element with css selector "#cboxNext"
-  And I wait 2 seconds
+  And I wait for AJAX to finish
   Then I click on the element with css selector "#cboxNext"
-  And I wait 2 seconds
+  And I wait for AJAX to finish
   Then I click on the element with css selector "#cboxNext"
-  And I wait 2 seconds
+  And I wait for AJAX to finish
   Then I click on the element with css selector "#cboxNext"
-  And I wait 2 seconds
+  And I wait for AJAX to finish
   Then I click on the element with css selector "#cboxNext"
-  And I wait 2 seconds
+  And I wait for AJAX to finish
   Then I click on the element with css selector "#cboxClose"
-  And I wait 2 seconds
+  And I wait for AJAX to finish
+  Then I should be on "behat-test-gallery"
+  And I should see "Behat Test Gallery"

--- a/includes/features/SU-SWS/stanford_gallery/stanford_gallery_block.feature
+++ b/includes/features/SU-SWS/stanford_gallery/stanford_gallery_block.feature
@@ -80,6 +80,7 @@ Scenario: Create stanford gallery node
 
   Then I should see 1 "#colorbox" element
   When I hover over the element "#cboxContent"
+  And I wait for AJAX to finish
   # TODO: Make these work...
   # Then I should see 1 "#colorbox .caption" element
   # Then I should see 1 "#colorbox .credits" element
@@ -114,6 +115,7 @@ Scenario: Create stanford gallery node
 
   Then I should see 1 "#colorbox" element
   When I hover over the element "#cboxContent"
+  And I wait for AJAX to finish
   Then I click on the element with css selector "#cboxNext"
   Then I wait for AJAX to finish
   Then I click on the element with css selector "#cboxNext"


### PR DESCRIPTION
Local is too speedy; need to wait for the modal to load before the next button is available.

Also, using `And I wait N seconds` is a hack 😆 