### PR TITLE
Fix user feature to work on local builds

### DIFF
--- a/includes/features/all_sites.feature
+++ b/includes/features/all_sites.feature
@@ -36,7 +36,7 @@ Feature: Every page will be checked for the following regions, elements and func
   @safe
   Scenario: Verify that /user page has the appropriate content
     Given I am on "user"
-    Then I should see the text "Login"
+    Then I should see the text "Log in"
 
   @safe @javascript
   Scenario: Verify that entering a search yields the correct result


### PR DESCRIPTION
The text "Login" is added by WMD; it's not present without that module (e.g., on local builds).

![2017-02-23-82245-screenshot](https://cloud.githubusercontent.com/assets/821106/23268068/772ba3ea-f9a1-11e6-955c-1df02d83e3f2.jpg)
![2017-02-23-82255-screenshot](https://cloud.githubusercontent.com/assets/821106/23268067/772ae66c-f9a1-11e6-9b83-a5d135bcf895.jpg)

To test:

1. Build a local build of any product
2. Run `includes/features/all_sites.feature` against it
3. Run `includes/features/all_sites.feature` against one of the build sites on Sites
4. Ensure that it passes on both