### PR TITLE
Add a short wait for the login fieldset to open

### DIFF
--- a/includes/bootstrap/SWSDrupalContext.php
+++ b/includes/bootstrap/SWSDrupalContext.php
@@ -80,6 +80,8 @@ class SWSDrupalContext extends DrupalContext implements Context, SnippetAcceptin
       // See Behat\Mink\Element\TraversableElement::clickLink
       $element->clickLink("Local User Login");
     }
+    // Shamelessly stolen from iWaitForAjaxToFinish().
+    $this->getSession()->wait(5000, '(typeof(jQuery)=="undefined" || (0 === jQuery.active && 0 === jQuery(\':animated\').length))');
     $element->fillField($this->getDrupalText('username_field'), $this->user->name);
     $element->fillField($this->getDrupalText('password_field'), $this->user->pass);
     $submit = $element->findButton($this->getDrupalText('log_in'));


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- I've been getting intermittent errors like this, and I think this change will resolve them:

```
    And I am logged in as a user with the "administrator" role # SWSDrupalContext::assertAuthenticatedByRole()
      element not visible
        (Session info: chrome=56.0.2924.87)
        (Driver info: chromedriver=2.24.417412 (ac882d3ce7c0d99292439bf3405780058fcca0a6),platform=Mac OS X 10.11.6 x86_64) (WARNING: The server did not provide any stacktrace information)
      Command duration or timeout: 51 milliseconds
      Build info: version: '3.0.1', revision: '1969d75', time: '2016-10-18 09:48:19 -0700'
      System info: host: 'TTS-MBP2011.stanford.edu', ip: '171.64.25.111', os.name: 'Mac OS X', os.arch: 'x86_64', os.version: '10.11.6', java.version: '1.8.0_73'
      Driver info: org.openqa.selenium.chrome.ChromeDriver
      Capabilities [{applicationCacheEnabled=false, rotatable=false, mobileEmulationEnabled=false, networkConnectionEnabled=false, chrome={chromedriverVersion=2.24.417412 (ac882d3ce7c0d99292439bf3405780058fcca0a6), userDataDir=/var/folders/h3/ghpj682n60984x76h550ynjw0000gp/T/.org.chromium.Chromium.HjeINJ}, takesHeapSnapshot=true, pageLoadStrategy=normal, databaseEnabled=false, handlesAlerts=true, hasTouchScreen=false, version=56.0.2924.87, platform=MAC, browserConnectionEnabled=false, nativeEvents=true, acceptSslCerts=true, locationContextEnabled=true, webStorageEnabled=true, browserName=chrome, takesScreenshot=true, javascriptEnabled=true, cssSelectorsEnabled=true}]
      Session ID: f26f26113b2a4503070ded54316af868 (WebDriver\Exception\ElementNotVisible)
```

# Needed By (Date)
- No deadline

# Urgency
- Not killer. I can test on this branch for a while and see if it resolves my issue.

# Steps to Test

1. Run any Scenario with a "Given I am logged in as a user with the 'role' role" step

# Affected Projects or Products
- *ARRYTHING*

# Associated Issues and/or People
- Anyone who should be notified? @kbrownell 
