### PR TITLE
Remove region from cache clear check

### DIFF
--- a/products/jsplus/features/site_owner.feature
+++ b/products/jsplus/features/site_owner.feature
@@ -106,4 +106,4 @@ Feature: Site Owner
     Given I am logged in as a user with the "site owner" role
     And I wait for the Site Actions drop down to appear
     And I click "Clear Site Cache" in the "Admin Shortcuts" region
-    Then I should see "Site Cache Cleared" in the "Console" region
+    Then I should see "Site Cache Cleared"


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Remove "Console" region from a JSPlus test for cache clearing.  We are interested in whether the cache has cleared, but not whether the message appears in a particular region, so we should be able to safely remove the region check in this test. 

# Needed By (Date)
- This is not yet blocking our effort to add Travis to the jumpstart-deployer.  It would, however, be useful to fix before testing begins next week on sites1 virtualization.

# Steps to Test

https://travis-ci.org/SU-SWS/stanford-jumpstart-deployer/jobs/208778757#L1067

# Affected Projects or Products
- Testing next week of JSPlus.