### PR TITLE
Updating paths for ServiceNow and social share config

### DIFF
--- a/sites/uat/features/high-value/social_share.feature
+++ b/sites/uat/features/high-value/social_share.feature
@@ -16,8 +16,6 @@ Feature: Social Share
     When I go to "admin/structure/types/manage/article"
     # Vertical Tabs gives us some weird labels for fieldsets
     And I click "Social ShareEnabled"
-    And I click "Social Networks"
-    And I wait for AJAX to finish
     And I check the box "Twitter"
     And I check the box "Facebook"
     And I press the "Save content type" button

--- a/sites/uat/features/high-value/social_share.feature
+++ b/sites/uat/features/high-value/social_share.feature
@@ -17,6 +17,7 @@ Feature: Social Share
     # Vertical Tabs gives us some weird labels for fieldsets
     And I click "Social ShareEnabled"
     And I click "Social Networks"
+    And I wait for AJAX to finish
     And I check the box "Twitter"
     And I check the box "Facebook"
     And I press the "Save content type" button

--- a/sites/uat/features/high-value/social_share.feature
+++ b/sites/uat/features/high-value/social_share.feature
@@ -9,7 +9,7 @@ Feature: Social Share
     Given the "social_share" module is enabled
     And I am logged in as a user with the "administrator" role
     And the cache has been cleared
-    And I am on "admin/config/content/social-share"
+    And I am on "admin/config/services/social-share"
     And I check the box "Article"
     And I press the "Save configuration" button
     Then I should see "The configuration options have been saved"

--- a/sites/uat/features/high-value/stanford_sites_helper.feature
+++ b/sites/uat/features/high-value/stanford_sites_helper.feature
@@ -83,13 +83,13 @@ Feature: Stanford Sites Helper Module
     | Create a new View      | admin/structure/views/add      |
 
   @api @safe @sites @deploy
-  Scenario: Link to HelpSU for administrative users
+  Scenario: Link to ServiceNow for administrative users
     Given I am logged in as a user with the "administrator" role
     And I am on "admin"
     Then I should see the heading "Get Help" in the "Help" region
-    And I should see "Problems using this service? Submit a HelpSU request." in the "Help" region
-    When I click "HelpSU request"
-    Then I should be on "https://helpsu.stanford.edu/helpsu/3.0/helpsu-form?pcat=sites"
+    And I should see "Problems using this service? Submit a service request." in the "Help" region
+    When I click "service request"
+    Then I should be on "https://stanford.service-now.com/it_services?id=sc_cat_item&sys_id=c44652e04f13ae0054c23f828110c7d9"
 
   @api @dev @sites @destructive
   Scenario: Stanford Sites Backup and Migrate profile
@@ -111,6 +111,6 @@ Feature: Stanford Sites Helper Module
     Then I should be on "admin/config/stanford-sites-helper/filequota/check"
     When I am on "admin/reports/status"
     And I click "request more storage" in the "File Storage Limit" row
-    Then I should be on "https://helpsu.stanford.edu/helpsu/3.0/helpsu-form?pcat=sites"
+    Then I should be on "https://stanford.service-now.com/it_services?id=sc_cat_item&sys_id=c44652e04f13ae0054c23f828110c7d9"
 
 


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Updates we plan to push next week direct users to ServiceNow instead of HelpSU.  Similarly, the path to configure social_share appears to have changed.  This branch includes updates to sites/uat tests with these links and paths.

# Needed By (Date)
- It would be great if we could merge this branch before next Tuesday, when we will be testing the live deployment of these module updates.

# Urgency
- Not terribly urgent.  Now that we know the cause of these failures, and that it is not due to a problem in the websites themselves, this is more a nice to have now.  But important to merge, eventually, as part of general test maintenance.

# Steps to Test
- Before committing these changes, I ran them locally against sites-uat.stanford.edu/drupal7-update-status to be sure they passed.  And they did pass.

# Affected Projects or Products
- https://stanfordits.atlassian.net/browse/DEVOPS-20