### PR TITLE
Add step definition to log in as user 1

### DIFF
--- a/includes/bootstrap/SWSFeatureContext.php
+++ b/includes/bootstrap/SWSFeatureContext.php
@@ -659,6 +659,10 @@ JS;
    */
   public function iAmLoggedInAsUserOne()
   {
+    // Check if logged in.
+    if ($this->loggedIn()) {
+      $this->logout();
+    }
     $url = $this->getDriver()->drush('user-login 1 --browser=0');
     $this->visitPath($url);
   }

--- a/includes/bootstrap/SWSFeatureContext.php
+++ b/includes/bootstrap/SWSFeatureContext.php
@@ -74,6 +74,13 @@ class SWSFeatureContext extends RawDrupalContext implements Context, SnippetAcce
   }
 
   /**
+   * @AfterScenario
+   */
+  public function after($event) {
+    $user = $this->drupalContext->logout();
+  }
+
+  /**
    * Initializes context.
    *
    * Every scenario gets its own context object.
@@ -646,5 +653,15 @@ JS;
 
     throw new \Exception(sprintf('The "%s" checkbox is not disabled', $selector));
   }
+
+  /**
+   * @Given I am logged in as User One
+   */
+  public function iAmLoggedInAsUserOne()
+  {
+    $url = $this->getDriver()->drush('user-login 1 --browser=0');
+    $this->visitPath($url);
+  }
+
 
 }

--- a/includes/bootstrap/SWSFeatureContext.php
+++ b/includes/bootstrap/SWSFeatureContext.php
@@ -657,8 +657,7 @@ JS;
   /**
    * @Given I am logged in as User One
    */
-  public function iAmLoggedInAsUserOne()
-  {
+  public function iAmLoggedInAsUserOne() {
     // Check if logged in.
     if ($this->loggedIn()) {
       $this->logout();


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Add a step definition, "Given I am logged in as User One"
- User 1 has different, "special" permissions compared to a user with the "administrator" role. This step definition allows you to log in as User 1, and then logs out after the Scenario.
- Note 1: It [does not appear that this functionality is desired in the drupalextension](https://github.com/jhedstrom/drupalextension/issues/454), so I'm adding it in our custom Feature Context.
- Note 2: Adding the logout step as an `AfterScenario` hook might be too big of a hammer. I am open to discussion whether that should be `AfterFeature` or even `AfterSuite`. However, I wanted to ensure that User 1's session was destroyed. See [hooks](http://docs.behat.org/en/v2.5/guides/3.hooks.html).

# Needed By (Date)
- Within the next week maybe? 1.30.18?

# Criticality
- How critical is this PR on a 1-10 scale? 3

# Steps to Test

1. Check out this branch
2. Create and run the following Scenario while tailing the Drupal watchdog logs:
```
  @api @javascript
  Scenario: User One login
    Given I am logged in as User One
    And I wait 10 seconds
```
3. Verify that the logs show the following:
```
Session opened for admin.   
User admin used one-time login link at time <timestamp>
Session closed for admin. 
```
4. Optionally verify in the browser that Behat logs in as User 1.

# Affected Projects or Products
- ACSF
