### PR TITLE
Remove core-specific access denied language

### DIFF
--- a/products/acsf/features/php-administrator.feature
+++ b/products/acsf/features/php-administrator.feature
@@ -49,7 +49,6 @@ Feature: PHP
     Then I should see "This form is disabled"
     Given I am on "admin/config/system/backup_migrate/restore"
     Then I should see "Access denied"
-    And I should see "You are not authorized to access this page."
     And the response status code should be 403
 
   @api
@@ -71,39 +70,39 @@ Feature: PHP
     And the cache has been cleared
     When I am on "admin/structure/context/import"
     Then I should see "Access denied"
-    And I should see "You are not authorized to access this page."
+#    And I should see "You are not authorized to access this page."
     And the response status code should be 403
     When I am on "admin/appearance/delta/import"
     Then I should see "Access denied"
-    And I should see "You are not authorized to access this page."
+#    And I should see "You are not authorized to access this page."
     And the response status code should be 403
     When I am on "admin/config/development/js-injector/import"
     Then I should see "Access denied"
-    And I should see "You are not authorized to access this page."
+#    And I should see "You are not authorized to access this page."
     And the response status code should be 403
     When I am on "admin/config/media/jw_player/import"
     Then I should see "Access denied"
-    And I should see "You are not authorized to access this page."
+#    And I should see "You are not authorized to access this page."
     And the response status code should be 403
     When I am on "admin/structure/openlayers/layers/import"
     Then I should see "Access denied"
-    And I should see "You are not authorized to access this page."
+#    And I should see "You are not authorized to access this page."
     And the response status code should be 403
     When I am on "admin/structure/openlayers/maps/import"
     Then I should see "Access denied"
-    And I should see "You are not authorized to access this page."
+#    And I should see "You are not authorized to access this page."
     And the response status code should be 403
     When I am on "admin/structure/openlayers/projections/import"
     Then I should see "Access denied"
-    And I should see "You are not authorized to access this page."
+#    And I should see "You are not authorized to access this page."
     And the response status code should be 403
     When I am on "admin/structure/openlayers/styles/import"
     Then I should see "Access denied"
-    And I should see "You are not authorized to access this page."
+#    And I should see "You are not authorized to access this page."
     And the response status code should be 403
     When I am on "admin/structure/services/import"
     Then I should see "Access denied"
-    And I should see "You are not authorized to access this page."
+#    And I should see "You are not authorized to access this page."
     And the response status code should be 403
 
   @api
@@ -113,7 +112,7 @@ Feature: PHP
     And the cache has been cleared
     When I am on "admin/structure/feeds/import"
     Then I should see "Access denied"
-    And I should see "You are not authorized to access this page."
+#    And I should see "You are not authorized to access this page."
     And the response status code should be 403
 
   @api
@@ -131,7 +130,7 @@ Feature: PHP
     And the cache has been cleared
     When I am on "admin/structure/pages/import"
     Then I should see "Access denied"
-    And I should see "You are not authorized to access this page."
+#    And I should see "You are not authorized to access this page."
     And the response status code should be 403
 
   @api
@@ -164,7 +163,7 @@ Feature: PHP
     And the "views_ui" module is enabled
     And I go to "admin/structure/views/import"
     Then I should see "Access denied"
-    And I should see "You are not authorized to access this page."
+#    And I should see "You are not authorized to access this page."
     And the response status code should be 403
 
   @api

--- a/products/acsf/features/php-administrator.feature
+++ b/products/acsf/features/php-administrator.feature
@@ -70,39 +70,30 @@ Feature: PHP
     And the cache has been cleared
     When I am on "admin/structure/context/import"
     Then I should see "Access denied"
-#    And I should see "You are not authorized to access this page."
     And the response status code should be 403
     When I am on "admin/appearance/delta/import"
     Then I should see "Access denied"
-#    And I should see "You are not authorized to access this page."
     And the response status code should be 403
     When I am on "admin/config/development/js-injector/import"
     Then I should see "Access denied"
-#    And I should see "You are not authorized to access this page."
     And the response status code should be 403
     When I am on "admin/config/media/jw_player/import"
     Then I should see "Access denied"
-#    And I should see "You are not authorized to access this page."
     And the response status code should be 403
     When I am on "admin/structure/openlayers/layers/import"
     Then I should see "Access denied"
-#    And I should see "You are not authorized to access this page."
     And the response status code should be 403
     When I am on "admin/structure/openlayers/maps/import"
     Then I should see "Access denied"
-#    And I should see "You are not authorized to access this page."
     And the response status code should be 403
     When I am on "admin/structure/openlayers/projections/import"
     Then I should see "Access denied"
-#    And I should see "You are not authorized to access this page."
     And the response status code should be 403
     When I am on "admin/structure/openlayers/styles/import"
     Then I should see "Access denied"
-#    And I should see "You are not authorized to access this page."
     And the response status code should be 403
     When I am on "admin/structure/services/import"
     Then I should see "Access denied"
-#    And I should see "You are not authorized to access this page."
     And the response status code should be 403
 
   @api
@@ -112,7 +103,6 @@ Feature: PHP
     And the cache has been cleared
     When I am on "admin/structure/feeds/import"
     Then I should see "Access denied"
-#    And I should see "You are not authorized to access this page."
     And the response status code should be 403
 
   @api
@@ -130,7 +120,6 @@ Feature: PHP
     And the cache has been cleared
     When I am on "admin/structure/pages/import"
     Then I should see "Access denied"
-#    And I should see "You are not authorized to access this page."
     And the response status code should be 403
 
   @api
@@ -163,7 +152,6 @@ Feature: PHP
     And the "views_ui" module is enabled
     And I go to "admin/structure/views/import"
     Then I should see "Access denied"
-#    And I should see "You are not authorized to access this page."
     And the response status code should be 403
 
   @api

--- a/products/acsf/features/php-userone.feature
+++ b/products/acsf/features/php-userone.feature
@@ -134,7 +134,6 @@ Feature: PHP
     And the "views_ui" module is enabled
     And I go to "admin/structure/views/import"
     Then I should see "Access denied"
-    And I should see "You are not authorized to access this page."
 
   @api @javascript
   Scenario: Views Bulk Operations Chainsaw Mode - with Javascript


### PR DESCRIPTION
Our tests were checking for the string, "You are not authorized to access this page". WMD takes this over and uses "This content has been restricted by the author or by the site administrator."

We're already checking for the string "Access Denied" and a 403 response, so this step is superfluous anyhow.