### PR TITLE
SOE-2685: added tests for the related mag. article to department land…

### DIFF
--- a/sites/engineering/features/AA_landing_page.feature
+++ b/sites/engineering/features/AA_landing_page.feature
@@ -58,8 +58,8 @@ Feature: Ensure items on the AA landing page appear as expected
     Then I should see a "#block-bean-aeronautics-astronautics-resear" element
 
   @safe
-  Scenario: Verify users can view the Recent News view
+  Scenario: Verify users can view the related magazine article view
     Given I am on "faculty-research/departments/aeronautics-astronautics"
     Then I should see a "a" element in the "Content Bottom" region
-    Then I should see a "#block-views-98ef3755ed7cc9ac83eba0d66243ce4c" element
+    Then I should see a ".view-stanford-magazine-article-department" element
     Then I should see the text "Visit the"

--- a/sites/engineering/features/BioE_landing_page.feature
+++ b/sites/engineering/features/BioE_landing_page.feature
@@ -58,8 +58,8 @@ Feature: Ensure items on the BioE landing page appear as expected
     Then I should see a "#block-bean-bioengineering-information-for" element
 
   @safe
-  Scenario: Verify users can view the Recent News view
+  Scenario: Verify users can view the related magazine article view
     Given I am on "faculty-research/departments/bioengineering"
     Then I should see a "a" element in the "Content Lower" region
-    Then I should see a "#block-views-98ef3755ed7cc9ac83eba0d66243ce4c" element
+    Then I should see a ".view-stanford-magazine-article-department" element
     Then I should see the text "Visit the"

--- a/sites/engineering/features/CEE_landing_page.feature
+++ b/sites/engineering/features/CEE_landing_page.feature
@@ -58,8 +58,8 @@ Feature: Ensure items on the CEE landing page appear as expected
     Then I should see a "#block-bean-civil-environmental-engineeri-2" element
 
   @safe
-  Scenario: Verify users can view the Recent News view
+  Scenario: Verify users can view the related magazine article view
     Given I am on "faculty-research/departments/civil-environmental-engineering"
     Then I should see a "a" element in the "Content Bottom" region
-    Then I should see a "#block-views-98ef3755ed7cc9ac83eba0d66243ce4c" element
+    Then I should see a ".view-stanford-magazine-article-department" element
     Then I should see the text "Visit the"

--- a/sites/engineering/features/CS_landing_page.feature
+++ b/sites/engineering/features/CS_landing_page.feature
@@ -58,8 +58,8 @@ Feature: Ensure items on the CS landing page appear as expected
     Then I should see a "#block-bean-cs-information-for" element
 
   @safe
-  Scenario: Verify users can view the Recent News view
+  Scenario: Verify users can view the related magazine article view
     Given I am on "faculty-research/departments/computer-science"
     Then I should see a "a" element in the "Content Lower" region
-    Then I should see a "#block-views-98ef3755ed7cc9ac83eba0d66243ce4c" element
+    Then I should see a ".view-stanford-magazine-article-department" element
     Then I should see the text "Visit the"

--- a/sites/engineering/features/ChemE_landing_page.feature
+++ b/sites/engineering/features/ChemE_landing_page.feature
@@ -58,8 +58,8 @@ Feature: Ensure items on the ChemE landing page appear as expected
     Then I should see a "#block-bean-cheme-info-for" element
 
   @safe
-  Scenario: Verify users can view the Recent News view
+  Scenario: Verify users can view the related magazine article view
     Given I am on "faculty-research/departments/chemical-engineering"
     Then I should see a "a" element in the "Content Lower" region
-    Then I should see a "#block-views-98ef3755ed7cc9ac83eba0d66243ce4c" element
+    Then I should see a ".view-stanford-magazine-article-department" element
     Then I should see the text "Visit the"

--- a/sites/engineering/features/EE_landing_page.feature
+++ b/sites/engineering/features/EE_landing_page.feature
@@ -58,8 +58,8 @@ Feature: Ensure items on the EE landing page appear as expected
     Then I should see a "#block-bean-ee-information-for" element
 
   @safe
-  Scenario: Verify users can view the Recent News view
+  Scenario: Verify users can view the related magazine article view
     Given I am on "faculty-research/departments/electrical-engineering"
     Then I should see a "a" element in the "Content Lower" region
-    Then I should see a "#block-views-98ef3755ed7cc9ac83eba0d66243ce4c" element
+    Then I should see a ".view-stanford-magazine-article-department" element
     Then I should see the text "Visit the"

--- a/sites/engineering/features/ME_landing_page.feature
+++ b/sites/engineering/features/ME_landing_page.feature
@@ -58,8 +58,8 @@ Feature: Ensure items on the ME landing page appear as expected
     Then I should see a "#block-bean-me-information-for" element
 
   @safe
-  Scenario: Verify users can view the Recent News view
+  Scenario: Verify users can view the related magazine article view
     Given I am on "faculty-research/departments/mechanical-engineering"
     Then I should see a "a" element in the "Content Lower" region
-    Then I should see a "#block-views-98ef3755ed7cc9ac83eba0d66243ce4c" element
+    Then I should see a ".view-stanford-magazine-article-department" element
     Then I should see the text "Visit the"

--- a/sites/engineering/features/MSE_landing_page.feature
+++ b/sites/engineering/features/MSE_landing_page.feature
@@ -58,8 +58,8 @@ Feature: Ensure items on the MSE landing page appear as expected
     Then I should see a "#block-bean-mse-information-for" element
 
   @safe
-  Scenario: Verify users can view the Recent News view
+  Scenario: Verify users can view the related magazine article view
     Given I am on "faculty-research/departments/materials-science-engineering"
     Then I should see a "a" element in the "Content Lower" region
-    Then I should see a "#block-views-98ef3755ed7cc9ac83eba0d66243ce4c" element
+    Then I should see a ".view-stanford-magazine-article-department" element
     Then I should see the text "Visit the"

--- a/sites/engineering/features/MSandE_landing_page.feature
+++ b/sites/engineering/features/MSandE_landing_page.feature
@@ -58,8 +58,8 @@ Feature: Ensure items on the MSandE landing page appear as expected
     Then I should see a "#block-bean-msande-information-for" element
 
   @safe
-  Scenario: Verify users can view the Recent News view
+  Scenario: Verify users can view the related magazine article view
     Given I am on "faculty-research/departments/management-science-engineering"
     Then I should see a "a" element in the "Content Lower" region
-    Then I should see a "#block-views-98ef3755ed7cc9ac83eba0d66243ce4c" element
+    Then I should see a ".view-stanford-magazine-article-department" element
     Then I should see the text "Visit the"


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- This replaces the test for the news block on the department landing pages with the test for the related magazine article block.

# Needed By (5/4/2018)
- Sprint end, although it would be nice to have for testing the new release.

# Criticality
- Updates to reflect changes on _Prod_.
- Housekeeping


# Steps to Test
- Switch to this branch
- Navigate to the _Engineering_ directory
- Run the *live* test suite on _Stage_ or a clone of _Stage_.
`../../bin/behat -p sites-jse-soe-stage -s live features `


# Affects 
- SoE (School of Engineering website)

# Associated Issues and/or People
## Related JIRA ticket(s)
https://stanfordits.atlassian.net/browse/SOE-2685

## Related PRs

## More Information

## Folks to notify
@kerri-augenstein 


# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)