### PR TITLE
5.x soe 2950 banner stanford page

### DIFF
--- a/sites/engineering/features/AA_landing_page.feature
+++ b/sites/engineering/features/AA_landing_page.feature
@@ -7,10 +7,7 @@ Feature: Ensure items on the AA landing page appear as expected
   Scenario: Verify users can view the top banner
     Given I am on "faculty-research/departments/aeronautics-astronautics"
     Then I should see the "img" element in the "Top Full Width" region
-    Then I should see 1 or more ".view-stanford-page-top-banner" elements
-    And I should see 1 or more ".image-style-full-width-banner-tall" elements
-    Then I should see the text "Scroll to"
-    And I should see 1 or more ".page-feat-caption-container" elements
+    Then I should see 1 or more ".image-style-full-width-banner-short" elements
 
   @safe
   Scenario: Verify users can view all the blocks

--- a/sites/engineering/features/AA_landing_page.feature
+++ b/sites/engineering/features/AA_landing_page.feature
@@ -58,8 +58,8 @@ Feature: Ensure items on the AA landing page appear as expected
     Then I should see a "#block-bean-aeronautics-astronautics-resear" element
 
   @safe
-  Scenario: Verify users can view the Recent News view
+  Scenario: Verify users can view the related magazine article view
     Given I am on "faculty-research/departments/aeronautics-astronautics"
     Then I should see a "a" element in the "Content Bottom" region
-    Then I should see a "#block-views-98ef3755ed7cc9ac83eba0d66243ce4c" element
+    Then I should see a ".view-stanford-magazine-article-department" element
     Then I should see the text "Visit the"

--- a/sites/engineering/features/BioE_landing_page.feature
+++ b/sites/engineering/features/BioE_landing_page.feature
@@ -7,10 +7,7 @@ Feature: Ensure items on the BioE landing page appear as expected
   Scenario: Verify users can view the top banner
     Given I am on "faculty-research/departments/bioengineering"
     Then I should see the "img" element in the "Top Full Width" region
-    Then I should see 1 or more ".view-stanford-page-top-banner" elements
-    And I should see 1 or more ".image-style-full-width-banner-tall" elements
-    Then I should see the text "Scroll to"
-    And I should see 1 or more ".page-feat-caption-container" elements
+    Then I should see 1 or more ".image-style-full-width-banner-short" elements
 
   @safe
   Scenario: Verify users can view all the blocks

--- a/sites/engineering/features/BioE_landing_page.feature
+++ b/sites/engineering/features/BioE_landing_page.feature
@@ -58,8 +58,8 @@ Feature: Ensure items on the BioE landing page appear as expected
     Then I should see a "#block-bean-bioengineering-information-for" element
 
   @safe
-  Scenario: Verify users can view the Recent News view
+  Scenario: Verify users can view the related magazine article view
     Given I am on "faculty-research/departments/bioengineering"
     Then I should see a "a" element in the "Content Lower" region
-    Then I should see a "#block-views-98ef3755ed7cc9ac83eba0d66243ce4c" element
+    Then I should see a ".view-stanford-magazine-article-department" element
     Then I should see the text "Visit the"

--- a/sites/engineering/features/CEE_landing_page.feature
+++ b/sites/engineering/features/CEE_landing_page.feature
@@ -58,8 +58,8 @@ Feature: Ensure items on the CEE landing page appear as expected
     Then I should see a "#block-bean-civil-environmental-engineeri-2" element
 
   @safe
-  Scenario: Verify users can view the Recent News view
+  Scenario: Verify users can view the related magazine article view
     Given I am on "faculty-research/departments/civil-environmental-engineering"
     Then I should see a "a" element in the "Content Bottom" region
-    Then I should see a "#block-views-98ef3755ed7cc9ac83eba0d66243ce4c" element
+    Then I should see a ".view-stanford-magazine-article-department" element
     Then I should see the text "Visit the"

--- a/sites/engineering/features/CEE_landing_page.feature
+++ b/sites/engineering/features/CEE_landing_page.feature
@@ -7,10 +7,7 @@ Feature: Ensure items on the CEE landing page appear as expected
   Scenario: Verify users can view the top banner
     Given I am on "faculty-research/departments/civil-environmental-engineering"
     Then I should see the "img" element in the "Top Full Width" region
-    Then I should see 1 or more ".view-stanford-page-top-banner" elements
-    And I should see 1 or more ".image-style-full-width-banner-tall" elements
-    Then I should see the text "Scroll to"
-    And I should see 1 or more ".page-feat-caption-container" elements
+    Then I should see 1 or more ".image-style-full-width-banner-short" elements
 
   @safe
   Scenario: Verify users can view all the blocks

--- a/sites/engineering/features/CS_landing_page.feature
+++ b/sites/engineering/features/CS_landing_page.feature
@@ -58,8 +58,8 @@ Feature: Ensure items on the CS landing page appear as expected
     Then I should see a "#block-bean-cs-information-for" element
 
   @safe
-  Scenario: Verify users can view the Recent News view
+  Scenario: Verify users can view the related magazine article view
     Given I am on "faculty-research/departments/computer-science"
     Then I should see a "a" element in the "Content Lower" region
-    Then I should see a "#block-views-98ef3755ed7cc9ac83eba0d66243ce4c" element
+    Then I should see a ".view-stanford-magazine-article-department" element
     Then I should see the text "Visit the"

--- a/sites/engineering/features/CS_landing_page.feature
+++ b/sites/engineering/features/CS_landing_page.feature
@@ -7,10 +7,7 @@ Feature: Ensure items on the CS landing page appear as expected
   Scenario: Verify users can view the top banner
     Given I am on "faculty-research/departments/computer-science"
     Then I should see the "img" element in the "Top Full Width" region
-    Then I should see 1 or more ".view-stanford-page-top-banner" elements
-    And I should see 1 or more ".image-style-full-width-banner-tall" elements
-    Then I should see the text "Scroll to"
-    And I should see 1 or more ".page-feat-caption-container" elements
+    Then I should see 1 or more ".image-style-full-width-banner-short" elements
 
   @safe
   Scenario: Verify users can view all the blocks

--- a/sites/engineering/features/ChemE_landing_page.feature
+++ b/sites/engineering/features/ChemE_landing_page.feature
@@ -58,8 +58,8 @@ Feature: Ensure items on the ChemE landing page appear as expected
     Then I should see a "#block-bean-cheme-info-for" element
 
   @safe
-  Scenario: Verify users can view the Recent News view
+  Scenario: Verify users can view the related magazine article view
     Given I am on "faculty-research/departments/chemical-engineering"
     Then I should see a "a" element in the "Content Lower" region
-    Then I should see a "#block-views-98ef3755ed7cc9ac83eba0d66243ce4c" element
+    Then I should see a ".view-stanford-magazine-article-department" element
     Then I should see the text "Visit the"

--- a/sites/engineering/features/ChemE_landing_page.feature
+++ b/sites/engineering/features/ChemE_landing_page.feature
@@ -7,10 +7,7 @@ Feature: Ensure items on the ChemE landing page appear as expected
   Scenario: Verify users can view the top banner
     Given I am on "faculty-research/departments/chemical-engineering"
     Then I should see the "img" element in the "Top Full Width" region
-    Then I should see 1 or more ".view-stanford-page-top-banner" elements
-    And I should see 1 or more ".image-style-full-width-banner-tall" elements
-    Then I should see the text "Scroll to"
-    And I should see 1 or more ".page-feat-caption-container" elements
+    Then I should see 1 or more ".image-style-full-width-banner-short" elements
 
   @safe
   Scenario: Verify users can view all the blocks

--- a/sites/engineering/features/EE_landing_page.feature
+++ b/sites/engineering/features/EE_landing_page.feature
@@ -58,8 +58,8 @@ Feature: Ensure items on the EE landing page appear as expected
     Then I should see a "#block-bean-ee-information-for" element
 
   @safe
-  Scenario: Verify users can view the Recent News view
+  Scenario: Verify users can view the related magazine article view
     Given I am on "faculty-research/departments/electrical-engineering"
     Then I should see a "a" element in the "Content Lower" region
-    Then I should see a "#block-views-98ef3755ed7cc9ac83eba0d66243ce4c" element
+    Then I should see a ".view-stanford-magazine-article-department" element
     Then I should see the text "Visit the"

--- a/sites/engineering/features/EE_landing_page.feature
+++ b/sites/engineering/features/EE_landing_page.feature
@@ -7,10 +7,7 @@ Feature: Ensure items on the EE landing page appear as expected
   Scenario: Verify users can view the top banner
     Given I am on "faculty-research/departments/electrical-engineering"
     Then I should see the "img" element in the "Top Full Width" region
-    Then I should see 1 or more ".view-stanford-page-top-banner" elements
-    And I should see 1 or more ".image-style-full-width-banner-tall" elements
-    Then I should see the text "Scroll to"
-    And I should see 1 or more ".page-feat-caption-container" elements
+    Then I should see 1 or more ".image-style-full-width-banner-short" elements
 
   @safe
   Scenario: Verify users can view all the blocks

--- a/sites/engineering/features/ME_landing_page.feature
+++ b/sites/engineering/features/ME_landing_page.feature
@@ -58,8 +58,8 @@ Feature: Ensure items on the ME landing page appear as expected
     Then I should see a "#block-bean-me-information-for" element
 
   @safe
-  Scenario: Verify users can view the Recent News view
+  Scenario: Verify users can view the related magazine article view
     Given I am on "faculty-research/departments/mechanical-engineering"
     Then I should see a "a" element in the "Content Lower" region
-    Then I should see a "#block-views-98ef3755ed7cc9ac83eba0d66243ce4c" element
+    Then I should see a ".view-stanford-magazine-article-department" element
     Then I should see the text "Visit the"

--- a/sites/engineering/features/ME_landing_page.feature
+++ b/sites/engineering/features/ME_landing_page.feature
@@ -7,10 +7,7 @@ Feature: Ensure items on the ME landing page appear as expected
   Scenario: Verify users can view the top banner
     Given I am on "faculty-research/departments/mechanical-engineering"
     Then I should see the "img" element in the "Top Full Width" region
-    Then I should see 1 or more ".view-stanford-page-top-banner" elements
-    And I should see 1 or more ".image-style-full-width-banner-tall" elements
-    Then I should see the text "Scroll to"
-    And I should see 1 or more ".page-feat-caption-container" elements
+    Then I should see 1 or more ".image-style-full-width-banner-short" elements
 
   @safe
   Scenario: Verify users can view all the blocks

--- a/sites/engineering/features/MSE_landing_page.feature
+++ b/sites/engineering/features/MSE_landing_page.feature
@@ -58,8 +58,8 @@ Feature: Ensure items on the MSE landing page appear as expected
     Then I should see a "#block-bean-mse-information-for" element
 
   @safe
-  Scenario: Verify users can view the Recent News view
+  Scenario: Verify users can view the related magazine article view
     Given I am on "faculty-research/departments/materials-science-engineering"
     Then I should see a "a" element in the "Content Lower" region
-    Then I should see a "#block-views-98ef3755ed7cc9ac83eba0d66243ce4c" element
+    Then I should see a ".view-stanford-magazine-article-department" element
     Then I should see the text "Visit the"

--- a/sites/engineering/features/MSE_landing_page.feature
+++ b/sites/engineering/features/MSE_landing_page.feature
@@ -7,10 +7,7 @@ Feature: Ensure items on the MSE landing page appear as expected
   Scenario: Verify users can view the top banner
     Given I am on "faculty-research/departments/materials-science-engineering"
     Then I should see the "img" element in the "Top Full Width" region
-    Then I should see 1 or more ".view-stanford-page-top-banner" elements
-    And I should see 1 or more ".image-style-full-width-banner-tall" elements
-    Then I should see the text "Scroll to"
-    And I should see 1 or more ".page-feat-caption-container" elements
+    Then I should see 1 or more ".image-style-full-width-banner-short" elements
 
   @safe
   Scenario: Verify users can view all the blocks

--- a/sites/engineering/features/MSandE_landing_page.feature
+++ b/sites/engineering/features/MSandE_landing_page.feature
@@ -58,8 +58,8 @@ Feature: Ensure items on the MSandE landing page appear as expected
     Then I should see a "#block-bean-msande-information-for" element
 
   @safe
-  Scenario: Verify users can view the Recent News view
+  Scenario: Verify users can view the related magazine article view
     Given I am on "faculty-research/departments/management-science-engineering"
     Then I should see a "a" element in the "Content Lower" region
-    Then I should see a "#block-views-98ef3755ed7cc9ac83eba0d66243ce4c" element
+    Then I should see a ".view-stanford-magazine-article-department" element
     Then I should see the text "Visit the"

--- a/sites/engineering/features/MSandE_landing_page.feature
+++ b/sites/engineering/features/MSandE_landing_page.feature
@@ -7,10 +7,7 @@ Feature: Ensure items on the MSandE landing page appear as expected
   Scenario: Verify users can view the top banner
     Given I am on "faculty-research/departments/management-science-engineering"
     Then I should see the "img" element in the "Top Full Width" region
-    Then I should see 1 or more ".view-stanford-page-top-banner" elements
-    And I should see 1 or more ".image-style-full-width-banner-tall" elements
-    Then I should see the text "Scroll to"
-    And I should see 1 or more ".page-feat-caption-container" elements
+    Then I should see 1 or more ".image-style-full-width-banner-short" elements
 
   @safe
   Scenario: Verify users can view all the blocks

--- a/sites/engineering/features/SoE_future_landing_page.feature
+++ b/sites/engineering/features/SoE_future_landing_page.feature
@@ -7,10 +7,7 @@ Feature: Ensure items on the SoE Future landing page appear as expected
   Scenario: Verify users can view the top banner
     Given I am on "about/soe-future"
     Then I should see the "img" element in the "Top Full Width" region
-    Then I should see 1 or more ".view-stanford-page-top-banner" elements
-    And I should see 1 or more ".image-style-full-width-banner-tall" elements
-    Then I should see the text "Scroll to"
-    And I should see 1 or more ".page-feat-caption-container" elements
+    Then I should see 1 or more ".image-style-full-width-banner-short" elements
 
   @safe
   Scenario: Verify users can view all the blocks

--- a/sites/engineering/features/about_landing_page.feature
+++ b/sites/engineering/features/about_landing_page.feature
@@ -7,10 +7,7 @@ Feature: Ensure items on the About landing page appear as expected
   Scenario: Verify users can view the top banner
     Given I am on "about"
     Then I should see the "img" element in the "Top Full Width" region
-    Then I should see 1 or more ".view-stanford-page-top-banner" elements
-    And I should see 1 or more ".image-style-full-width-banner-tall" elements
-    Then I should see the text "Scroll to"
-    And I should see 1 or more ".page-feat-caption-container" elements
+    Then I should see 1 or more ".image-style-full-width-banner-short" elements
 
   @safe
   Scenario: Verify users can view all the blocks

--- a/sites/engineering/features/admission_and_aid_landing_page.feature
+++ b/sites/engineering/features/admission_and_aid_landing_page.feature
@@ -4,15 +4,6 @@ Feature: Ensure items on the Admission and Aid landing page appear as expected
   I want to be able to view all the Admission and Aid landing page blocks in their appropriate regions
 
   @safe
-  Scenario: Verify users can view the top banner
-    Given I am on "admission-aid"
-    Then I should see the "img" element in the "Top Full Width" region
-    Then I should see 1 or more ".view-stanford-page-top-banner" elements
-    And I should see 1 or more ".image-style-full-width-banner-tall" elements
-    Then I should see the text "Scroll to"
-    And I should see 1 or more ".page-feat-caption-container" elements
-
-  @safe
   Scenario: Verify users can view all the blocks
     Given I am on "admission-aid"
     Then I should see 3 or more ".bean-stanford-call-to-action" elements

--- a/sites/engineering/features/alumni_landing_page.feature
+++ b/sites/engineering/features/alumni_landing_page.feature
@@ -7,10 +7,7 @@ Feature: Ensure items on the Alumni landing page appear as expected
   Scenario: Verify users can view the top banner
     Given I am on "get-involved/alumni"
     Then I should see the "img" element in the "Top Full Width" region
-    Then I should see 1 or more ".view-stanford-page-top-banner" elements
-    And I should see 1 or more ".image-style-full-width-banner-tall" elements
-    Then I should see the text "Scroll to"
-    And I should see 1 or more ".page-feat-caption-container" elements
+    Then I should see 1 or more ".image-style-full-width-banner-short" elements
 
   @safe
   Scenario: Verify users can view all the blocks

--- a/sites/engineering/features/engineering_diversity_landing_page.feature
+++ b/sites/engineering/features/engineering_diversity_landing_page.feature
@@ -7,10 +7,7 @@ Feature: Ensure items on the Engineering Diversity landing page appear as expect
   Scenario: Verify users can view the top banner
     Given I am on "students-academics/engineering-diversity-programs"
     Then I should see the "img" element in the "Top Full Width" region
-    Then I should see 1 or more ".view-stanford-page-top-banner" elements
-    And I should see 1 or more ".image-style-full-width-banner-tall" elements
-    Then I should see the text "Scroll to"
-    And I should see 1 or more ".page-feat-caption-container" elements
+    Then I should see 1 or more ".image-style-full-width-banner-short" elements
 
   @safe
   Scenario: Verify users can view all the blocks

--- a/sites/engineering/features/engineering_homepage.feature
+++ b/sites/engineering/features/engineering_homepage.feature
@@ -7,10 +7,7 @@ Feature: Ensure items on the homepage appear as expected
   Scenario: Verify users can view the top banner
     Given I am on the homepage
     Then I should see the "img" element in the "Top Full Width" region
-    Then I should see 1 or more ".view-stanford-page-top-banner" elements
-    And I should see 1 or more ".image-style-full-width-banner-tall" elements
-    Then I should see the text "Scroll to"
-    And I should see 1 or more ".page-feat-caption-container" elements
+    Then I should see 1 or more ".image-style-full-width-banner-short" elements
 
   @safe
   Scenario: Verify users can view all the blocks

--- a/sites/engineering/features/faculty_and_research_landing_page.feature
+++ b/sites/engineering/features/faculty_and_research_landing_page.feature
@@ -7,10 +7,7 @@ Feature: Ensure items on the Faculty and Research landing page appear as expecte
   Scenario: Verify users can view the top banner
     Given I am on "faculty-research"
     Then I should see the "img" element in the "Top Full Width" region
-    Then I should see 1 or more ".view-stanford-page-top-banner" elements
-    And I should see 1 or more ".image-style-full-width-banner-tall" elements
-    Then I should see the text "Scroll to"
-    And I should see 1 or more ".page-feat-caption-container" elements
+    Then I should see 1 or more ".image-style-full-width-banner-short" elements
 
   @safe
   Scenario: Verify users can view all the blocks

--- a/sites/engineering/features/get_involved_landing_page.feature
+++ b/sites/engineering/features/get_involved_landing_page.feature
@@ -7,10 +7,7 @@ Feature: Ensure items on the Get Involved landing page appear as expected
   Scenario: Verify users can view the top banner
     Given I am on "get-involved"
     Then I should see the "img" element in the "Top Full Width" region
-    Then I should see 1 or more ".view-stanford-page-top-banner" elements
-    And I should see 1 or more ".image-style-full-width-banner-tall" elements
-    Then I should see the text "Scroll to"
-    And I should see 1 or more ".page-feat-caption-container" elements
+    Then I should see 1 or more ".image-style-full-width-banner-short" elements
 
   @safe
   Scenario: Verify users can view all the blocks

--- a/sites/engineering/features/student_experience_landing_page.feature
+++ b/sites/engineering/features/student_experience_landing_page.feature
@@ -7,10 +7,7 @@ Feature: Ensure items on the Student Experience landing page appear as expected
   Scenario: Verify users can view the top banner
     Given I am on "students-academics/student-experience"
     Then I should see the "img" element in the "Top Full Width" region
-    Then I should see 1 or more ".view-stanford-page-top-banner" elements
-    And I should see 1 or more ".image-style-full-width-banner-tall" elements
-    Then I should see the text "Scroll to"
-    And I should see 1 or more ".page-feat-caption-container" elements
+    Then I should see 1 or more ".image-style-full-width-banner-short" elements
 
   @safe
   Scenario: Verify users can view all the blocks

--- a/sites/engineering/features/students_and_academics_landing_page.feature
+++ b/sites/engineering/features/students_and_academics_landing_page.feature
@@ -7,10 +7,7 @@ Feature: Ensure items on the Students and Academics landing page appear as expec
   Scenario: Verify users can view the top banner
     Given I am on "students-and-academics"
     Then I should see the "img" element in the "Top Full Width" region
-    Then I should see 1 or more ".view-stanford-page-top-banner" elements
-    And I should see 1 or more ".image-style-full-width-banner-tall" elements
-    Then I should see the text "Scroll to"
-    And I should see 1 or more ".page-feat-caption-container" elements
+    Then I should see 1 or more ".image-style-full-width-banner-short" elements
 
   @safe
   Scenario: Verify users can view the WYSIWYG text (and buttons)


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
This updates the Behat tests for sites/engineering to account for the change in banner images

# Needed By (5/11/2018)
- Sprint end

# Criticality
- Fixes broken Behat tests

# Steps to Test
- Switch to this branch: 5.x-SOE-2950-banner-stanford-page
- Navigate to sites/engineering
- Run Behat tests:
`../../bin/behat  -p <SoE-site-profile> -s live features/
`
# Affects 
- SoE (School of Engineering website)

# Associated Issues and/or People
## Related JIRA ticket(s)
https://stanfordits.atlassian.net/browse/SOE-2950
https://stanfordits.atlassian.net/browse/SOE-2685

## Related PRs
https://github.com/SU-SWS/linky_clicky/pull/196

## More Information
This work is required for this pr:
https://github.com/SU-SWS/linky_clicky/pull/196

## Folks to notify
@kerri-augenstein 


# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)