### PR TITLE
Fix CAPx/Travis hanging

### DIFF
--- a/includes/features/SU-SWS/stanford_capx/capx_auto_nodetitle.feature
+++ b/includes/features/SU-SWS/stanford_capx/capx_auto_nodetitle.feature
@@ -24,4 +24,5 @@ Feature: CAPX Auto Node Title Support
     Then I am on "admin/config/capx/mapper/delete/capx_auto_nodetitle_mapper"
     And I press the "Yes, please delete" button
     # Travis hangs at the end for some unknown reason. The logout step is silly, but prevents the hang.
-    Then I am on "user/logout"
+    When I am on the homepage
+

--- a/includes/features/SU-SWS/stanford_capx/capx_auto_nodetitle.feature
+++ b/includes/features/SU-SWS/stanford_capx/capx_auto_nodetitle.feature
@@ -23,6 +23,6 @@ Feature: CAPX Auto Node Title Support
 
     Then I am on "admin/config/capx/mapper/delete/capx_auto_nodetitle_mapper"
     And I press the "Yes, please delete" button
-    # Travis hangs at the end for some unknown reason. The logout step is silly, but prevents the hang.
+    # Travis hangs at the end for some unknown reason. The homepage step is silly, but prevents the hang.
     When I am on the homepage
 

--- a/includes/features/SU-SWS/stanford_capx/capx_issue_collector.feature
+++ b/includes/features/SU-SWS/stanford_capx/capx_issue_collector.feature
@@ -11,3 +11,4 @@ Feature: Stanford CAPx Issue Collector
     Then I should see "capx_issue_collector.js"
     # Travis hangs at the end for some unknown reason. The logout step is silly, but prevents the hang.
     Then I am on "user/logout"
+

--- a/includes/features/SU-SWS/stanford_capx/capx_issue_collector.feature
+++ b/includes/features/SU-SWS/stanford_capx/capx_issue_collector.feature
@@ -9,6 +9,6 @@ Feature: Stanford CAPx Issue Collector
     Given I am logged in as a user with the "administrator" role
     And I am on "admin/config/capx/settings"
     Then I should see "capx_issue_collector.js"
-    # Travis hangs at the end for some unknown reason. The logout step is silly, but prevents the hang.
+    # Travis hangs at the end for some unknown reason. The homepage step is silly, but prevents the hang.
     When I am on the homepage
 

--- a/includes/features/SU-SWS/stanford_capx/capx_issue_collector.feature
+++ b/includes/features/SU-SWS/stanford_capx/capx_issue_collector.feature
@@ -10,5 +10,5 @@ Feature: Stanford CAPx Issue Collector
     And I am on "admin/config/capx/settings"
     Then I should see "capx_issue_collector.js"
     # Travis hangs at the end for some unknown reason. The logout step is silly, but prevents the hang.
-    Then I am on "user/logout"
+    When I am on the homepage
 


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Travis hangs for some reason. This appears to fix it.

# Needed By (Date)
- Socorro go-live

# Criticality
- How critical is this PR on a 1-10 scale? 3/10

# Steps to Test

1. See hanging Travis build at https://travis-ci.org/SU-SWS/stanford_capx/builds/397122959
2. See Travis build that is failing for a different reason at https://travis-ci.org/SU-SWS/stanford_capx/builds/397573860

# Affected Projects or Products
- Does this PR impact any particular projects, products, or modules?

# Associated Issues and/or People
- JIRA ticket
- Other PRs: https://github.com/SU-SWS/stanford_capx/pull/184 (I would like to update `.travis.yml` to point at the default branch of linky_clicky before merging that PR)
- Anyone who should be notified? ( @pookmish )

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)