### PR TITLE
SOE-3298: Update per RawDrupalContext:: property has been deprecated

### DIFF
--- a/includes/bootstrap/SWSDrupalContext.php
+++ b/includes/bootstrap/SWSDrupalContext.php
@@ -60,14 +60,12 @@ class SWSDrupalContext extends DrupalContext implements Context, SnippetAcceptin
    * The WebAuth Module for Drupal (WMD) hides the user login form in a collapsible fieldset.
    * We need to open that fieldset up to be able to fill out the fields
    */
-  public function login() {
+  public function login(\stdClass $user) {
+    $manager = $this->getUserManager();
+
     // Check if logged in.
     if ($this->loggedIn()) {
       $this->logout();
-    }
-
-    if (!$this->user) {
-      throw new \Exception('Tried to login without a user.');
     }
 
     $this->getSession()->visit($this->locatePath('/user'));
@@ -84,8 +82,8 @@ class SWSDrupalContext extends DrupalContext implements Context, SnippetAcceptin
       $this->getSession()
         ->wait(5000, '(typeof(jQuery)=="undefined" || (0 === jQuery.active && 0 === jQuery(\':animated\').length))');
     }
-    $element->fillField($this->getDrupalText('username_field'), $this->user->name);
-    $element->fillField($this->getDrupalText('password_field'), $this->user->pass);
+    $element->fillField($this->getDrupalText('username_field'), $user->name);
+    $element->fillField($this->getDrupalText('password_field'), $user->pass);
     $submit = $element->findButton($this->getDrupalText('log_in'));
     if (empty($submit)) {
       throw new \Exception(sprintf("No submit button at %s", $this->getSession()
@@ -96,8 +94,16 @@ class SWSDrupalContext extends DrupalContext implements Context, SnippetAcceptin
     $submit->click();
 
     if (!$this->loggedIn()) {
-      throw new \Exception(sprintf("Failed to log in as user '%s' with role '%s'", $this->user->name, $this->user->role));
+      if (isset($user->role)) {
+
+        throw new \Exception(sprintf("Unable to determine if logged in because 'log_out' link cannot be found for user '%s' with role '%s'", $user->name, $user->role));
+      }
+      else {
+        throw new \Exception(sprintf("Unable to determine if logged in because 'log_out' link cannot be found for user '%s'", $user->name));
+      }
     }
+
+    $manager->setCurrentUser($user);
   }
 
 


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
See https://stanfordits.atlassian.net/browse/SOE-3298
- This addresses the " RawDrupalContext::$user property has been deprecated." error 

# Needed By (Date)
- Sprint end

# Criticality
- Fixes broken stuff


# Steps to Test
Check out this branch:
`git checkout 5.x-soe-3298-deprecated-user`
Make sure composer is up-to-date:
Navigate to the top directory in Linky-Clicky and run
`composer install`
Run the Behat tests:
`../../bin/behat -s dev -p <your-soe-profile> features/stanford_soe_helper_collection/soe_helper_collection_content.feature`

# Affects 
- SoE (School of Engineering website)

# Associated Issues and/or People
## Related JIRA ticket(s)
https://stanfordits.atlassian.net/browse/SOE-3298

## Related PRs
This PR is a pre-requisite for  [5.x-soe-3339-dynomite](https://github.com/SU-SWS/linky_clicky/tree/5.x-soe-3339-dynomite)

## More Information

## Folks to notify
@annawatt 
# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)