### PR TITLE
SITES-1305: Add acquia_purge_d8cache Feature

### DIFF
--- a/includes/bootstrap/SWSFeatureContext.php
+++ b/includes/bootstrap/SWSFeatureContext.php
@@ -677,7 +677,7 @@ JS;
   }
 
 
-    /**
+   /**
    * @Then I should see no duplicate HTML with :arg1
    */
   public function iShouldSeeNoDuplicateHtmlWith($arg1) {
@@ -706,4 +706,15 @@ JS;
       throw new ExpectationException($message, $session);
     }
   }
+
+  /**
+   * @Given I refresh the page
+   */
+  public function iRefreshThePage() {
+    $mink = $this->minkContext;
+    $session = $mink->getSession();
+    // http://mink.behat.org/en/latest/guides/session.html#interacting-with-the-page
+    $session->reload();
+  }
+
 }

--- a/products/jsa/features/cache-expiration.feature
+++ b/products/jsa/features/cache-expiration.feature
@@ -103,3 +103,19 @@ Feature: Cache Expiration
     And I refresh the page
     Then I should see "War and Peace"
 
+  @api @destructive @javascript
+  Scenario: Create a Course and assure that it appears on the Courses page
+    # Prime the cache.
+    Given I am an anonymous user
+    And I am on "courses/search?combine=flux&field_s_course_section_year_value_selective=All&field_s_course_term_value=All"
+    Then I should not see "Flux Capacitor Design and Implementation"
+    Given I am logged in as a user with the "site owner" role
+    # Not enabling any of the required modules here, because it should "just work".
+    And I am on "node/add/stanford-course"
+    Then I fill in "edit-title" with "Flux Capacitor Design and Implementation"
+    And I press the "Save" button
+    Then I should see "Course Flux Capacitor Design and Implementation has been created"
+    Given I am an anonymous user
+    And I am on "courses/search?combine=flux&field_s_course_section_year_value_selective=All&field_s_course_term_value=All"
+    And I refresh the page
+    Then I should see "Flux Capacitor Design and Implementation"

--- a/products/jsa/features/cache-expiration.feature
+++ b/products/jsa/features/cache-expiration.feature
@@ -137,3 +137,32 @@ Feature: Cache Expiration
     And I am on "courses/search?combine=flux&field_s_course_section_year_value_selective=All&field_s_course_term_value=All"
     And I refresh the page
     Then I should see "Flux Capacitor Design and Implementation"
+
+  @api @destructive @javascript
+  Scenario: Create an item in the Main Menu and assure that it appears
+    # Prime the cache.
+    Given I am an anonymous user
+    And I am on the homepage
+    And I refresh the page
+    Then I should not see "New Menu Item"
+    Given I am logged in as a user with the "site owner" role
+    # Not enabling any of the required modules here, because it should "just work".
+    And I am on "admin/structure/menu/manage/main-menu"
+    And I click "Add link"
+    And I fill in "Menu link title" with "New Menu Item"
+    And I fill in "Path" with "<front>"
+    And I press the "Save" button
+    Then I should see "Your configuration has been saved."
+    Given I am an anonymous user
+    And I am on the homepage
+    And I refresh the page
+    Then I should see "New Menu Item"
+    Given I am logged in as a user with the "site owner" role
+    And I am on "admin/structure/menu/manage/main-menu"
+    And I click "delete" in the "New Menu Item" row
+    And I press the "Confirm" button
+    Then I should see "The menu link New Menu Item has been deleted."
+    Given I am an anonymous user
+    And I am on the homepage
+    And I refresh the page
+    Then I should not see "New Menu Item"

--- a/products/jsa/features/cache-expiration.feature
+++ b/products/jsa/features/cache-expiration.feature
@@ -16,7 +16,7 @@ Feature: Cache Expiration
     Then I fill in "title" with "[random]"
     And I press the "Save" button
     Then I should see "News Item [random:1] has been created"
-    And I am an anonymous user
+    Given I am an anonymous user
     And I am on "news/recent-news"
     And I refresh the page
     Then I should see "[random:1]"
@@ -32,7 +32,7 @@ Feature: Cache Expiration
     Then I fill in "title" with "[random]"
     And I press the "Save" button
     Then I should see "News Item [random:1] has been created"
-    And I am an anonymous user
+    Given I am an anonymous user
     And I am on the homepage
     And I refresh the page
     Then I should see "[random:1]"
@@ -48,7 +48,7 @@ Feature: Cache Expiration
     Then I fill in "title" with "[random]"
     And I press the "Save" button
     Then I should see "Stanford Event [random:1] has been created"
-    And I am an anonymous user
+    Given I am an anonymous user
     And I am on "events/upcoming-events"
     And I refresh the page
     Then I should see "[random:1]"
@@ -64,7 +64,42 @@ Feature: Cache Expiration
     Then I fill in "title" with "[random]"
     And I press the "Save" button
     Then I should see "Stanford Event [random:1] has been created"
-    And I am an anonymous user
+    Given I am an anonymous user
     And I am on the homepage
     And I refresh the page
     Then I should see "[random:1]"
+
+  @api @destructive @javascript
+  Scenario: Create a Person (faculty) and assure that she appears on the Faculty page
+    # Prime the cache.
+    Given I am an anonymous user
+    And I am on "people/faculty"
+    Given I am logged in as a user with the "site owner" role
+    # Not enabling any of the required modules here, because it should "just work".
+    And I am on "node/add/stanford-person"
+    Then I fill in "First name" with "Annie"
+    And I fill in "Last Name" with "Aardvark"
+    And I check "Faculty"
+    And I press the "Save" button
+    Then I should see "Person Annie Aardvark has been created"
+    Given I am an anonymous user
+    And I am on "people/faculty"
+    And I refresh the page
+    Then I should see "Annie Aardvark"
+
+  @api @destructive @javascript
+  Scenario: Create a Publication and assure that it appears on the Publications page
+    # Prime the cache.
+    Given I am an anonymous user
+    And I am on "publications"
+    Given I am logged in as a user with the "site owner" role
+    # Not enabling any of the required modules here, because it should "just work".
+    And I am on "node/add/stanford-publication"
+    Then I fill in "edit-title" with "War and Peace"
+    And I press the "Save" button
+    Then I should see "Publication War and Peace has been created"
+    Given I am an anonymous user
+    And I am on "publications"
+    And I refresh the page
+    Then I should see "War and Peace"
+

--- a/products/jsa/features/cache-expiration.feature
+++ b/products/jsa/features/cache-expiration.feature
@@ -16,9 +16,9 @@ Feature: Cache Expiration
     Then I fill in "title" with "[random]"
     And I press the "Save" button
     Then I should see "News Item [random:1] has been created"
-    Given I am an anonymous user
-    And I wait 60 seconds
+    And I am an anonymous user
     And I am on "news/recent-news"
+    And I refresh the page
     Then I should see "[random:1]"
 
   @api @destructive @javascript
@@ -32,9 +32,9 @@ Feature: Cache Expiration
     Then I fill in "title" with "[random]"
     And I press the "Save" button
     Then I should see "News Item [random:1] has been created"
-    Given I am an anonymous user
-    And I wait 60 seconds
+    And I am an anonymous user
     And I am on the homepage
+    And I refresh the page
     Then I should see "[random:1]"
 
   @api @destructive @javascript
@@ -48,9 +48,9 @@ Feature: Cache Expiration
     Then I fill in "title" with "[random]"
     And I press the "Save" button
     Then I should see "Stanford Event [random:1] has been created"
-    Given I am an anonymous user
-    And I wait 60 seconds
+    And I am an anonymous user
     And I am on "events/upcoming-events"
+    And I refresh the page
     Then I should see "[random:1]"
 
   @api @destructive @javascript
@@ -64,7 +64,7 @@ Feature: Cache Expiration
     Then I fill in "title" with "[random]"
     And I press the "Save" button
     Then I should see "Stanford Event [random:1] has been created"
-    Given I am an anonymous user
-    And I wait 60 seconds
+    And I am an anonymous user
     And I am on the homepage
+    And I refresh the page
     Then I should see "[random:1]"

--- a/products/jsa/features/cache-expiration.feature
+++ b/products/jsa/features/cache-expiration.feature
@@ -37,6 +37,24 @@ Feature: Cache Expiration
     And I refresh the page
     Then I should see "[random:1]"
 
+  @api @destructive
+  Scenario: Create a News Item and assure that it does not invalidate the cache on the Upcoming Events page
+    # Prime the cache.
+    Given I am an anonymous user
+    And I am on "events/upcoming-events"
+    And I refresh the page
+    Then the response header "X-Cache" should contain "HIT"
+    Given I am logged in as a user with the "site owner" role
+    # Not enabling any of the required modules here, because it should "just work".
+    And I am on "node/add/stanford-news-item"
+    Then I fill in "title" with "[random]"
+    And I press the "Save" button
+    Then I should see "News Item [random:1] has been created"
+    Given I am an anonymous user
+    And I am on "events/upcoming-events"
+    And I refresh the page
+    Then the response header "X-Cache" should contain "HIT"
+
   @api @destructive @javascript
   Scenario: Create an Event and assure that it appears on the Upcoming Events page
     # Prime the cache.

--- a/products/jsa/features/cache-expiration.feature
+++ b/products/jsa/features/cache-expiration.feature
@@ -1,0 +1,70 @@
+Feature: Cache Expiration
+  In order to ensure that content changes are reflected immediately for anonymous users
+  As a Site Owner
+  I want to create, edit, and delete content
+  As an anonymous user
+  I want to see those changes immediately
+
+  @api @destructive @javascript
+  Scenario: Create a News Item and assure that it appears on the Recent News page
+    # Prime the cache.
+    Given I am an anonymous user
+    And I am on "news/recent-news"
+    Given I am logged in as a user with the "site owner" role
+    # Not enabling any of the required modules here, because it should "just work".
+    And I am on "node/add/stanford-news-item"
+    Then I fill in "title" with "[random]"
+    And I press the "Save" button
+    Then I should see "News Item [random:1] has been created"
+    Given I am an anonymous user
+    And I wait 60 seconds
+    And I am on "news/recent-news"
+    Then I should see "[random:1]"
+
+  @api @destructive @javascript
+  Scenario: Create a News Item and assure that it appears on the homepage
+    # Prime the cache.
+    Given I am an anonymous user
+    And I am on the homepage
+    Given I am logged in as a user with the "site owner" role
+    # Not enabling any of the required modules here, because it should "just work".
+    And I am on "node/add/stanford-news-item"
+    Then I fill in "title" with "[random]"
+    And I press the "Save" button
+    Then I should see "News Item [random:1] has been created"
+    Given I am an anonymous user
+    And I wait 60 seconds
+    And I am on the homepage
+    Then I should see "[random:1]"
+
+  @api @destructive @javascript
+  Scenario: Create an Event and assure that it appears on the Upcoming Events page
+    # Prime the cache.
+    Given I am an anonymous user
+    And I am on "events/upcoming-events"
+    Given I am logged in as a user with the "site owner" role
+    # Not enabling any of the required modules here, because it should "just work".
+    And I am on "node/add/stanford-event"
+    Then I fill in "title" with "[random]"
+    And I press the "Save" button
+    Then I should see "Stanford Event [random:1] has been created"
+    Given I am an anonymous user
+    And I wait 60 seconds
+    And I am on "events/upcoming-events"
+    Then I should see "[random:1]"
+
+  @api @destructive @javascript
+  Scenario: Create an Event and assure that it appears on the homepage
+    # Prime the cache.
+    Given I am an anonymous user
+    And I am on the homepage
+    Given I am logged in as a user with the "site owner" role
+    # Not enabling any of the required modules here, because it should "just work".
+    And I am on "node/add/stanford-event"
+    Then I fill in "title" with "[random]"
+    And I press the "Save" button
+    Then I should see "Stanford Event [random:1] has been created"
+    Given I am an anonymous user
+    And I wait 60 seconds
+    And I am on the homepage
+    Then I should see "[random:1]"


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Test acquia_purge_d8cache

# Needed By (Date)
- Within a week or so should be fine

# Criticality
- How critical is this PR on a 1-10 scale? 6/10
- Good for testing the functionality and ensuring it's working as designed

# Steps to Test

1. Create a JSA site on `dev` (or on `prod` after 7PM on 6.18.19)
2. Run the Feature at `products/jsa/features/cache-expiration.feature`
3. Ensure all scenarios pass

Note that the events Scenarios are dependent on when they run and whether the time defaults to future or past, based on 5 minute intervals. Per discussion, we didn't think that it warrants the effort of creating a custom step definition to create an event in the future.

# Affected Projects or Products
- ACSF

# Associated Issues and/or People
- JIRA ticket: SITES-1305
- Anyone who should be notified? ( @sherakama )

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)