### PR TITLE
DEVOPS-260: node_convert and xmlsitemap compatibility

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,31 @@
+# READY FOR REVIEW/NOT READY
+- (Edit the above to reflect status)
+
+# Summary
+- TL;DR - what's this PR for?
+
+# Review By (Date)
+- When does this need to be reviewed by?
+
+# Criticality
+- How critical is this PR on a 1-10 scale?
+- E.g., it affects one site, or every site and product?
+
+# Steps to Test
+
+1. Do this
+2. Then this
+3. Then this
+
+# Affected Projects or Products
+- Does this PR impact any particular projects, products, or modules?
+
+# Associated Issues and/or People
+- JIRA ticket
+- Other PRs
+- Any other contextual information that might be helpful (e.g., description of a bug that this PR fixes, new functionality that it adds, etc.)
+- Anyone who should be notified? (`@mention` them here)
+
+# See Also
+- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
+

--- a/sites/uat/features/low-value/node_convert.feature
+++ b/sites/uat/features/low-value/node_convert.feature
@@ -7,6 +7,8 @@ Feature: Node Convert
   @api @javascript @content @dev @destructive
   Scenario: Node Convert
     Given the "node_convert" module is enabled
+    # Testing patch in https://www.drupal.org/project/node_convert/issues/2394047
+    And the "xmlsitemap" module is enabled
     And the cache has been cleared
     And I am logged in as a user with the "administrator" role
     When I am on "node/add/page"


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- What it says on the tin
- Adds PR template

# Needed By (Date)
- Whenever. After https://github.com/SU-SWS/acsf-cardinald7/pull/265. Wait until after D8CORE v1.0.0 release

# Criticality
- How critical is this PR on a 1-10 scale? 1/10

# Steps to Test

1. Run the changed feature and ensure that it passes.

# Affected Projects or Products
- ACSF

# Associated Issues and/or People
- JIRA ticket: DEVOPS-260
- Other PRs: https://github.com/SU-SWS/acsf-cardinald7/pull/265

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)